### PR TITLE
Create new folder for Auth Screens and Link it with Splash Screen.

### DIFF
--- a/daemon/lib/screens/auth_screens/authentication_screen.dart
+++ b/daemon/lib/screens/auth_screens/authentication_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class AuthenticationScreen extends StatelessWidget {
+  const AuthenticationScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text("Authentication Screen")));
+  }
+}

--- a/daemon/lib/screens/splash_screen.dart
+++ b/daemon/lib/screens/splash_screen.dart
@@ -1,7 +1,31 @@
+import 'dart:async';
+
+import 'package:daemon/screens/auth_screens/authentication_screen.dart';
 import 'package:flutter/material.dart';
 
-class SplashScreen extends StatelessWidget {
+class SplashScreen extends StatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    startTime();
+  }
+
+  startTime() async {
+    var duration = const Duration(seconds: 3);
+    return Timer(duration, route);
+  }
+
+  route() {
+    Navigator.pushReplacement(context,
+        MaterialPageRoute(builder: (context) => const AuthenticationScreen()));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +63,13 @@ class SplashScreen extends StatelessWidget {
                     fontFamily: 'Open Sans',
                     fontSize: 50),
               ),
+              SizedBox(
+                height: 20,
+              ),
+              CircularProgressIndicator(
+                strokeWidth: 2,
+                color: Colors.white,
+              )
             ])),
       ),
     );


### PR DESCRIPTION
New Auth Screens folder has been created, this folder will contain three dart files : 

1.  authentication_screen : This file will get an auth object and decide whether to navigate to Login screen or to Sign Up screen.
2.  login_screen : Login screen will allow existing user to login to the app and thus will contain a login form.
3. sign_up_screen : Sign Up screen will allow user to create a new account and thus will contain a create new account or sign up form.

Splash Screen now calls a method that waits for a fixed duration while showing the contents of the splash screen and once the duration is complete it navigates to Authentication Screen.